### PR TITLE
Add .harness scaffold, ADR folder, eval_plan field, and README improvements

### DIFF
--- a/.harness/README.md
+++ b/.harness/README.md
@@ -1,0 +1,55 @@
+# .harness/
+
+This directory contains the **test harness** for this project — executable scenarios, evaluators, mocks, and traces that prove specs are satisfied under controlled conditions.
+
+## Structure
+
+```
+.harness/
+├── scenarios/       # Declarative eval scenarios (agent tasks, prompt runs, API calls)
+├── evaluators/      # Custom evaluator logic (scripts, rubrics, graders)
+├── mocks/           # Mock tools, APIs, and data sources used during eval runs
+└── traces/          # Captured execution traces (gitignored by default)
+```
+
+## Relationship to OpenSpec
+
+OpenSpec defines **what should be true** — via `acceptance_criteria` and `test_plan`.
+
+The harness proves **whether it is true** — via reproducible, measurable, executable runs.
+
+| OpenSpec artifact | Harness artifact |
+|---|---|
+| `acceptance_criteria` | Scenario `expected` assertions |
+| `test_plan` | Scenario `metrics` + evaluator rubrics |
+| `eval_plan.scenarios` | Scenario files in `scenarios/` |
+| `eval_plan.metrics` | Evaluator scripts in `evaluators/` |
+
+## Running scenarios
+
+```bash
+# Run all scenarios (adapt to your harness runner)
+gh openspec harness run
+
+# Run a single scenario
+gh openspec harness run scenarios/example-agent-task.scenario.yaml
+
+# Compare against a baseline trace
+gh openspec harness diff traces/baseline.json traces/latest.json
+```
+
+## Adding a scenario
+
+1. Create a file in `scenarios/` following the `example.scenario.yaml` format.
+2. Reference it in the relevant spec under `eval_plan.scenarios`.
+3. Run the scenario locally before opening a PR.
+4. Captured traces go in `traces/` — they are gitignored by default to keep the repo small.
+
+## When to use this
+
+- Any feature spec that involves an AI model, agent, or LLM-backed component.
+- Integration boundaries where behavior is probabilistic rather than deterministic.
+- Regression baselines for safety-critical or quality-sensitive flows.
+- Latency and cost budgets that need continuous monitoring.
+
+For purely deterministic code, standard unit/integration tests (defined in `test_plan`) are sufficient.

--- a/.harness/evaluators/README.md
+++ b/.harness/evaluators/README.md
@@ -1,0 +1,38 @@
+# evaluators/
+
+Evaluators are rubrics or scripts that score scenario runs against the `expected` assertions and `metrics` defined in each scenario file.
+
+## Types of evaluators
+
+| Type | Format | When to use |
+|---|---|---|
+| **Rubric** | Markdown file | LLM-as-judge — describe scoring criteria in natural language |
+| **Script** | Python / shell | Deterministic checks (regex, schema validation, threshold comparison) |
+| **Composite** | YAML pointing to multiple | Mix of rubric + script for hybrid evaluation |
+
+## Adding an evaluator
+
+Create a file in this directory and reference it from the scenario via `evaluator:`.
+
+### Rubric example (`citation-and-groundedness.md`)
+
+```markdown
+Score the response on the following axes (0.0 – 1.0 each):
+
+**citation_accuracy**: Every source cited by the agent must appear
+verbatim or near-verbatim in the input document. Deduct 0.1 per
+hallucinated citation.
+
+**groundedness**: Every factual claim in the summary must be traceable
+to a sentence in the input document. Deduct 0.1 per unsupported claim.
+```
+
+### Script example (`check-tool-call-count.sh`)
+
+```bash
+#!/usr/bin/env bash
+# Exits 1 if tool_calls in trace exceeds the scenario threshold.
+CALLS=$(jq '.tool_calls | length' "$1")
+MAX=$(jq '.thresholds.max_tool_calls' "$2")
+[ "$CALLS" -le "$MAX" ] && exit 0 || exit 1
+```

--- a/.harness/mocks/README.md
+++ b/.harness/mocks/README.md
@@ -1,0 +1,35 @@
+# mocks/
+
+Mock tools, APIs, and data sources used during harness scenario runs.
+
+Mocks provide **controlled, reproducible inputs** so that scenario results are
+deterministic and comparable across runs — even when the real tools are
+non-deterministic, rate-limited, or expensive.
+
+## What goes here
+
+| File type | Purpose |
+|---|---|
+| `*.json` | Stubbed API responses (tool call returns) |
+| `*.txt` / `*.md` | Sample documents, corpora, or knowledge-base content |
+| `*.yaml` | Mock tool definitions (name, description, parameters, canned return) |
+
+## Example: mocked tool response
+
+```yaml
+# mocks/search-tool.yaml
+tool: web_search
+query_pattern: ".*"       # match any query
+response:
+  results:
+    - title: "Example result"
+      url: "https://example.com"
+      snippet: "This is a canned search result used in harness runs."
+```
+
+## Guidelines
+
+- Keep mocks small and focused — they document assumptions, not production data.
+- Never commit real credentials, PII, or production snapshots here.
+- Name mocks after the tool or data source they replace (`stripe-payment.json`, `openai-chat.yaml`).
+- If a mock evolves significantly, add a short comment explaining what changed and why.

--- a/.harness/scenarios/example.scenario.yaml
+++ b/.harness/scenarios/example.scenario.yaml
@@ -1,0 +1,33 @@
+id: example-agent-task
+type: agent_eval
+
+description: |
+  Verify that the agent summarizes a document, cites its sources,
+  and does not fabricate facts not present in the input.
+
+input:
+  prompt: "Summarize this document and cite your sources."
+  document: ".harness/mocks/sample-document.txt"
+
+expected:
+  must_cite_sources: true
+  must_not_hallucinate: true
+  max_tool_calls: 5
+
+metrics:
+  - task_success       # Did the agent complete the task?
+  - citation_accuracy  # Are cited sources actually in the input?
+  - groundedness       # Is every claim traceable to the input?
+  - latency_ms         # Wall-clock time for the full run
+  - cost_estimate      # Estimated token cost in USD
+
+thresholds:
+  task_success: 1.0       # Must always succeed
+  citation_accuracy: 0.95 # Allow 5% miss rate on citation matching
+  groundedness: 0.90
+  latency_ms: 5000        # Fail if slower than 5 s
+  cost_estimate: 0.05     # Fail if estimated cost exceeds $0.05 per run
+
+evaluator: evaluators/citation-and-groundedness.md
+
+linked_spec: ".openspec/specs/example-feature.spec.yaml"

--- a/.openspec/templates/feature.spec.yaml
+++ b/.openspec/templates/feature.spec.yaml
@@ -35,6 +35,19 @@ implementation_skill: null
   # Overrides agents.implementation_skills.default in config.yaml.
   # Examples: "frontend-pro", "backend-pro", "data-eng-pro", "devops-pro", "mobile-pro"
 
+eval_plan:
+  # Optional. Use for features that involve an AI model, agent, or LLM-backed component.
+  # Leave the block empty (or remove it) for fully deterministic features — test_plan is enough.
+  scenarios: []
+    # - ".harness/scenarios/example.scenario.yaml"
+  metrics: []
+    # - task_success        # Did the agent complete the task?
+    # - groundedness        # Are all claims traceable to the input?
+    # - tool_accuracy       # Did the agent use the right tools correctly?
+    # - refusal_accuracy    # Did the agent refuse when it should have?
+    # - latency_ms          # Wall-clock time budget
+    # - cost_estimate       # Token cost budget in USD
+
 technical_notes: |
   <!-- Optional: constraints, dependencies, architecture decisions.
        Do not design the solution here — save implementation details for the PR. -->

--- a/README.md
+++ b/README.md
@@ -120,8 +120,15 @@ Three project skills are available in any Claude Code session:
 ├── specs/                   # Active spec files (one per feature/bugfix)
 │   └── example-feature.spec.yaml
 └── templates/
-    ├── feature.spec.yaml
+    ├── feature.spec.yaml    # Includes optional eval_plan for AI-backed features
     └── bugfix.spec.yaml
+
+.harness/                    # Eval harness — proves specs under controlled conditions
+├── scenarios/               # Declarative eval scenarios (agent tasks, prompt runs)
+│   └── example.scenario.yaml
+├── evaluators/              # Rubrics and scripts that score scenario runs
+├── mocks/                   # Mock tools, APIs, and data sources
+└── traces/                  # Captured execution traces (gitignored by default)
 
 .github/
 ├── workflows/
@@ -162,6 +169,8 @@ Three project skills are available in any Claude Code session:
 └── settings.json
 
 docs/
+├── adr/                         # Architecture Decision Records
+│   └── 0001-record-architecture-decisions.md
 └── BRANCH_PROTECTION.md         # Recommended ruleset configuration
 
 Governance (repo root):
@@ -200,6 +209,42 @@ Required fields: `title`, `description`, `acceptance_criteria`, `test_plan`, `st
 Status lifecycle: `draft` → `review` → `approved`
 
 > Code can only be written when status is `review` or `approved`.
+
+---
+
+## OpenSpec vs Harness
+
+OpenSpec defines **what should be true.**
+Tests and harnesses prove **whether it is true.**
+
+For normal software, this means unit, integration, and end-to-end tests — captured in each spec's `test_plan`.
+
+For AI systems, verification often requires more:
+
+| Concern | Tool |
+|---|---|
+| Functional correctness | Unit / integration tests (`test_plan`) |
+| Agent task success | Eval scenarios (`.harness/scenarios/`) |
+| Grounding and citation accuracy | Evaluators (`.harness/evaluators/`) |
+| Tool use correctness | Mocked tool runs (`.harness/mocks/`) |
+| Latency and cost budgets | Scenario `thresholds` + `metrics` |
+| Safety and refusal behavior | Scenario `expected` + evaluator rubrics |
+| Reproducible regression baselines | Captured traces (`.harness/traces/`) |
+
+When a spec involves an AI-backed component, add an `eval_plan` block — it links the spec to the harness scenarios that prove it:
+
+```yaml
+eval_plan:
+  scenarios:
+    - ".harness/scenarios/my-agent-task.scenario.yaml"
+  metrics:
+    - task_success
+    - groundedness
+    - tool_accuracy
+    - refusal_accuracy
+```
+
+The spec says *what* must be validated. The harness says *how* that validation is executed.
 
 ---
 

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,66 @@
+# ADR 0001: Record Architecture Decisions
+
+**Date:** 2026-01-01
+**Status:** Accepted
+
+---
+
+## Context
+
+AI agents can implement features quickly, but they have no persistent memory of
+*why* a particular approach was chosen over alternatives. Human developers share
+the same problem — but with more confidence and less RAM.
+
+Without a lightweight record of decisions, future contributors (human or AI) must
+reverse-engineer intent from code, leading to repeated debates, inconsistent
+extensions, and regressions that undo intentional trade-offs.
+
+## Decision
+
+We will use Architecture Decision Records (ADRs), stored in `docs/adr/`, to
+capture decisions that are significant enough to be worth explaining to a future
+reader.
+
+Each ADR is a short Markdown file with the following structure:
+
+```
+# ADR NNNN: <title>
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Deprecated | Superseded by ADR NNNN
+
+---
+
+## Context
+<Why this decision was needed. What forces are at play.>
+
+## Decision
+<What was decided and why. Be specific.>
+
+## Consequences
+<What becomes easier. What becomes harder. Any trade-offs accepted.>
+```
+
+ADRs are numbered sequentially and never deleted. A superseded ADR is marked
+`Superseded by ADR NNNN` and a new ADR explains the replacement.
+
+## Consequences
+
+- New decisions take 5–15 minutes to document.
+- Future contributors (including AI agents) have a searchable record of intent.
+- Decisions are easy to find: one directory, sequential filenames.
+- The record is append-only — no history is lost when decisions change.
+
+---
+
+## When to write an ADR
+
+Write one when you:
+
+- Choose a framework, library, or tool over a concrete alternative.
+- Reject an approach that looks obvious (explain why).
+- Accept a trade-off that will surprise a future reader.
+- Make a cross-cutting architectural change that affects more than one component.
+
+Skip it for implementation details, style choices, or decisions that are obvious
+from the code.


### PR DESCRIPTION
- Add .harness/ with scenarios/, evaluators/, mocks/, traces/ directories
  and example.scenario.yaml showing agent eval format with metrics/thresholds
- Add docs/adr/0001-record-architecture-decisions.md to establish ADR practice
  from day one, especially useful for AI-agent-driven repos
- Add optional eval_plan field to feature.spec.yaml template, linking specs
  to harness scenarios for AI-backed feature validation
- Update README: add "OpenSpec vs Harness" section explaining the distinction
  between spec intent and executable proof; update project structure tree

https://claude.ai/code/session_01793WnZZLcWgR59iHn4VUVg